### PR TITLE
Initialize WAS During Docker Build

### DIFF
--- a/nanoserver/Dockerfile
+++ b/nanoserver/Dockerfile
@@ -7,7 +7,8 @@ ADD ServiceMonitor.exe /ServiceMonitor.exe
 RUN dism.exe /online /add-package /packagepath:c:\install\Microsoft-NanoServer-IIS-Package_base_10-0-14393-0.cab & \
     dism.exe /online /add-package /packagepath:c:\install\Microsoft-NanoServer-IIS-Package_English_10-0-14393-0.cab & \
     dism.exe /online /add-package /packagepath:c:\install\Microsoft-NanoServer-IIS-Package_base_10-0-14393-0.cab & \
-    rd /s /q c:\install
+    rd /s /q c:\install & \
+    powershell -command {start-service was; While ((Get-ItemProperty HKLM:\SYSTEM\CurrentControlSet\Services\WAS\Parameters\ -Name NanoSetup -ErrorAction Ignore) -ne $null) {sleep 1}}
 
 EXPOSE 80
 


### PR DESCRIPTION
To avoid WAS initialization been interrupted during docker build, Start WAS immediately after IIS is Installed and wait until reg value NanoSetup under HKLM:\SYSTEM\CurrentControlSet\Services\WAS\Parameters\ is deleted.
https://github.com/Microsoft/iis-docker/issues/47