### PR TITLE
IIS Nano DockerFile wait for WAS Setup

### DIFF
--- a/nanoserver-sac2016/Dockerfile
+++ b/nanoserver-sac2016/Dockerfile
@@ -8,9 +8,9 @@ RUN dism.exe /online /add-package /packagepath:c:\install\Microsoft-NanoServer-I
     dism.exe /online /add-package /packagepath:c:\install\Microsoft-NanoServer-IIS-Package_English_10-0-14393-0.cab & \
     dism.exe /online /add-package /packagepath:c:\install\Microsoft-NanoServer-IIS-Package_base_10-0-14393-0.cab & \
     rd /s /q c:\install & \
-    powershell -NoProfile -Command \
-    start-service was; \
-    While ((Get-ItemProperty HKLM:\SYSTEM\CurrentControlSet\Services\WAS\Parameters\ -Name NanoSetup -ErrorAction Ignore) -ne $null) {sleep 1}
+    Powershell -NoProfile -Command \
+    Start-Service Was; \
+    While ((Get-ItemProperty HKLM:\SYSTEM\CurrentControlSet\Services\WAS\Parameters\ -Name NanoSetup -ErrorAction Ignore) -ne $null) {Sleep 1}
 
 EXPOSE 80
 

--- a/nanoserver-sac2016/Dockerfile
+++ b/nanoserver-sac2016/Dockerfile
@@ -10,7 +10,7 @@ RUN dism.exe /online /add-package /packagepath:c:\install\Microsoft-NanoServer-I
     rd /s /q c:\install & \
     Powershell -NoProfile -Command \
     Start-Service Was; \
-    While ((Get-ItemProperty HKLM:\SYSTEM\CurrentControlSet\Services\WAS\Parameters\ -Name NanoSetup -ErrorAction Ignore) -ne $null) {Sleep 1}
+    While ((Get-ItemProperty HKLM:\SYSTEM\CurrentControlSet\Services\WAS\Parameters\ -Name NanoSetup -ErrorAction Ignore) -ne $null) {Start-Sleep 1}
 
 EXPOSE 80
 

--- a/nanoserver-sac2016/Dockerfile
+++ b/nanoserver-sac2016/Dockerfile
@@ -8,7 +8,9 @@ RUN dism.exe /online /add-package /packagepath:c:\install\Microsoft-NanoServer-I
     dism.exe /online /add-package /packagepath:c:\install\Microsoft-NanoServer-IIS-Package_English_10-0-14393-0.cab & \
     dism.exe /online /add-package /packagepath:c:\install\Microsoft-NanoServer-IIS-Package_base_10-0-14393-0.cab & \
     rd /s /q c:\install & \
-    powershell -command {start-service was; While ((Get-ItemProperty HKLM:\SYSTEM\CurrentControlSet\Services\WAS\Parameters\ -Name NanoSetup -ErrorAction Ignore) -ne $null) {sleep 1}}
+    powershell -NoProfile -Command \
+    start-service was; \
+    While ((Get-ItemProperty HKLM:\SYSTEM\CurrentControlSet\Services\WAS\Parameters\ -Name NanoSetup -ErrorAction Ignore) -ne $null) {sleep 1}
 
 EXPOSE 80
 


### PR DESCRIPTION
After install IIS on Nano server, WAS should be given enough time to finish its initial setup. 
The line 
`powershell -command {start-service was; While ((Get-ItemProperty HKLM:\SYSTEM\CurrentControlSet\Services\WAS\Parameters\ -Name NanoSetup -ErrorAction Ignore) -ne $null) {sleep 1}}`
in inserted for that purpose. How ever, this command inside the {} is not executed due to the wrong formatting. This Commit uses the correct way to invoke powershell command and wait for WAS to setup.