### PR TITLE
update all IIS docker samples to use mcr.microsoft.com/windows/servercore/iis

### DIFF
--- a/samples/AdministrationApi/dockerfile
+++ b/samples/AdministrationApi/dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM microsoft/iis
+FROM mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 

--- a/samples/aspnetcoremodule/Dockerfile
+++ b/samples/aspnetcoremodule/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM microsoft/iis
+FROM mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 

--- a/samples/php/Dockerfile
+++ b/samples/php/Dockerfile
@@ -5,7 +5,7 @@
 # PHP 7.1 x64 running on IIS
 #
 
-FROM microsoft/iis AS php71
+FROM mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019 AS php71
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 


### PR DESCRIPTION
Update all IIS docker samples to use `mcr.microsoft.com/windows/servercore/iis` with ltsc2019 instead of using `microsoft/iis`.

cc @mbrown555 @bariscaglar 