### PR TITLE
Added IIS Insider

### DIFF
--- a/windowsservercore-insider/Dockerfile
+++ b/windowsservercore-insider/Dockerfile
@@ -25,4 +25,6 @@ RUN c:\windows\system32\inetsrv\appcmd.exe set config -section:system.applicatio
 
 EXPOSE 80
 
+WORKDIR /LogMonitor
+
 ENTRYPOINT C:\LogMonitor\LogMonitor.exe C:\ServiceMonitor.exe w3svc

--- a/windowsservercore-insider/Dockerfile
+++ b/windowsservercore-insider/Dockerfile
@@ -5,17 +5,21 @@ RUN powershell -Command `
     Add-WindowsFeature Web-Server; `
     New-Item -ItemType Directory C:\LogMonitor; `
     $downloads = `
-    @{ `
-        uri = 'https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe'; `
-        outFile = 'C:\ServiceMonitor.exe' `
-    }, @{ `
-        uri = 'https://github.com/microsoft/windows-container-tools/releases/download/v1.0/LogMonitor.exe'; `
-        outFile = 'C:\LogMonitor\LogMonitor.exe' `
-    }, @{ `
-        uri = 'https://raw.githubusercontent.com/microsoft/iis-docker/master/windowsservercore-insider/LogMonitorConfig.json'; `
-        outFile = 'C:\LogMonitor\LogMonitorConfig.json' `
-    }; `
-    $downloads.ForEach{ Invoke-WebRequest -UseBasicParsing -Uri $psitem.uri -OutFile $psitem.outFile }
+    @( `
+        @{ `
+            uri = 'https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe'; `
+            outFile = 'C:\ServiceMonitor.exe' `
+        }, `
+        @{ `
+            uri = 'https://github.com/microsoft/windows-container-tools/releases/download/v1.0/LogMonitor.exe'; `
+            outFile = 'C:\LogMonitor\LogMonitor.exe' `
+        }, `
+        @{ `
+            uri = 'https://raw.githubusercontent.com/microsoft/iis-docker/master/windowsservercore-insider/LogMonitorConfig.json'; `
+            outFile = 'C:\LogMonitor\LogMonitorConfig.json' `
+        } `
+    ); `
+    $downloads.ForEach({ Invoke-WebRequest -UseBasicParsing -Uri $psitem.uri -OutFile $psitem.outFile })
 
 RUN c:\windows\system32\inetsrv\appcmd.exe set config -section:system.applicationHost/sites /"[name='Default Web Site'].logFile.logTargetW3C:"File,ETW"" /commit:apphost
 

--- a/windowsservercore-insider/Dockerfile
+++ b/windowsservercore-insider/Dockerfile
@@ -1,4 +1,5 @@
 # escape=`
+
 FROM mcr.microsoft.com/windows/servercore/insider:10.0.19035.1
 
 RUN powershell -Command `
@@ -21,10 +22,13 @@ RUN powershell -Command `
     ); `
     $downloads.ForEach({ Invoke-WebRequest -UseBasicParsing -Uri $psitem.uri -OutFile $psitem.outFile })
 
+# Change the startup type of the IIS service from Automatic to Manual
+RUN sc config w3svc start=demand
+
+# Enable ETW logging for Default Web Site on IIS
 RUN c:\windows\system32\inetsrv\appcmd.exe set config -section:system.applicationHost/sites /"[name='Default Web Site'].logFile.logTargetW3C:"File,ETW"" /commit:apphost
 
 EXPOSE 80
 
-WORKDIR /LogMonitor
-
-ENTRYPOINT C:\LogMonitor\LogMonitor.exe C:\ServiceMonitor.exe w3svc
+# Start "C:\LogMonitor\LogMonitor.exe C:\ServiceMonitor.exe w3svc"
+ENTRYPOINT ["C:\\LogMonitor\\LogMonitor.exe", "C:\\ServiceMonitor.exe", "w3svc"]

--- a/windowsservercore-insider/Dockerfile
+++ b/windowsservercore-insider/Dockerfile
@@ -2,6 +2,7 @@
 
 FROM mcr.microsoft.com/windows/servercore/insider:10.0.19035.1
 
+# Install IIS, LogMonitor.exe and ServiceMonitor.exe
 RUN powershell -Command `
     Add-WindowsFeature Web-Server; `
     New-Item -ItemType Directory C:\LogMonitor; `

--- a/windowsservercore-insider/Dockerfile
+++ b/windowsservercore-insider/Dockerfile
@@ -25,4 +25,4 @@ RUN c:\windows\system32\inetsrv\appcmd.exe set config -section:system.applicatio
 
 EXPOSE 80
 
-ENTRYPOINT ["C:\\LogMonitor\\LogMonitor.exe", "C:\\ServiceMonitor.exe", "w3svc"]
+ENTRYPOINT C:\LogMonitor\LogMonitor.exe C:\\ServiceMonitor.exe w3svc

--- a/windowsservercore-insider/Dockerfile
+++ b/windowsservercore-insider/Dockerfile
@@ -3,16 +3,23 @@ FROM mcr.microsoft.com/windows/servercore/insider:10.0.19035.1
 
 RUN powershell -Command `
     Add-WindowsFeature Web-Server; `
-    Invoke-WebRequest -UseBasicParsing -Uri "https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe" -OutFile "C:\ServiceMonitor.exe"
-
-RUN powershell -Command `
     New-Item -ItemType Directory C:\LogMonitor; `
-    Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/microsoft/windows-container-tools/releases/download/v1.0/LogMonitor.exe" -OutFile "C:\LogMonitor\LogMonitor.exe"; `
-    Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/microsoft/iis-docker/master/windowsservercore-insider/LogMonitorConfig.json" -OutFile "C:\LogMonitor\LogMonitorConfig.json"
+    $downloads = `
+    @{ `
+        uri = 'https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe'; `
+        outFile = 'C:\ServiceMonitor.exe' `
+    }, @{ `
+        uri = 'https://github.com/microsoft/windows-container-tools/releases/download/v1.0/LogMonitor.exe'; `
+        outFile = 'C:\LogMonitor\LogMonitor.exe' `
+    }, @{ `
+        uri = 'https://raw.githubusercontent.com/microsoft/iis-docker/master/windowsservercore-insider/LogMonitorConfig.json'; `
+        outFile = 'C:\LogMonitor\LogMonitorConfig.json' `
+    }; `
+    $downloads.ForEach{ Invoke-WebRequest -UseBasicParsing -Uri $psitem.uri -OutFile $psitem.outFile }
 
-RUN c:\windows\system32\inetsrv\appcmd.exe set config  -section:system.applicationHost/sites /"[name='Default Web Site'].logFile.logTargetW3C:"File,ETW""  /commit:apphost
+RUN c:\windows\system32\inetsrv\appcmd.exe set config -section:system.applicationHost/sites /"[name='Default Web Site'].logFile.logTargetW3C:"File,ETW"" /commit:apphost
 
 EXPOSE 80
 
-SHELL ["C:\\LogMonitor\\LogMonitor.exe", "powershell.exe"]
+SHELL ["C:\\LogMonitor\\LogMonitor.exe", "cmd.exe", "/S", "/C"]
 ENTRYPOINT C:\ServiceMonitor.exe w3svc

--- a/windowsservercore-insider/Dockerfile
+++ b/windowsservercore-insider/Dockerfile
@@ -1,11 +1,16 @@
 # escape=`
-FROM mcr.microsoft.com/windows/insider:10.0.18362.113
-
+FROM mcr.microsoft.com/windows/servercore/insider:10.0.19035.1
 
 RUN powershell -Command `
     Add-WindowsFeature Web-Server; `
     Invoke-WebRequest -UseBasicParsing -Uri "https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe" -OutFile "C:\ServiceMonitor.exe"
 
-EXPOSE 80
+RUN powershell -Command `
+    New-Item -ItemType Directory C:\LogMonitor; `
+    Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/microsoft/windows-container-tools/releases/download/v1.0/LogMonitor.exe" -OutFile "C:\LogMonitor\LogMonitor.exe"; `
+    Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/microsoft/iis-docker/master/windowsservercore-insider/LogMonitorConfig.json" -OutFile "C:\LogMonitor\LogMonitorConfig.json"
 
-ENTRYPOINT ["C:\\ServiceMonitor.exe", "w3svc"]
+RUN c:\windows\system32\inetsrv\appcmd.exe set config  -section:system.applicationHost/sites /"[name='Default Web Site'].logFile.logTargetW3C:"File,ETW""  /commit:apphost
+
+SHELL ["C:\\LogMonitor\\LogMonitor.exe", "powershell.exe"]
+ENTRYPOINT C:\ServiceMonitor.exe w3svc

--- a/windowsservercore-insider/Dockerfile
+++ b/windowsservercore-insider/Dockerfile
@@ -25,5 +25,4 @@ RUN c:\windows\system32\inetsrv\appcmd.exe set config -section:system.applicatio
 
 EXPOSE 80
 
-SHELL ["C:\\LogMonitor\\LogMonitor.exe", "cmd.exe", "/S", "/C"]
-ENTRYPOINT C:\ServiceMonitor.exe w3svc
+ENTRYPOINT ["C:\\LogMonitor\\LogMonitor.exe", "C:\\ServiceMonitor.exe", "w3svc"]

--- a/windowsservercore-insider/Dockerfile
+++ b/windowsservercore-insider/Dockerfile
@@ -12,5 +12,7 @@ RUN powershell -Command `
 
 RUN c:\windows\system32\inetsrv\appcmd.exe set config  -section:system.applicationHost/sites /"[name='Default Web Site'].logFile.logTargetW3C:"File,ETW""  /commit:apphost
 
+EXPOSE 80
+
 SHELL ["C:\\LogMonitor\\LogMonitor.exe", "powershell.exe"]
 ENTRYPOINT C:\ServiceMonitor.exe w3svc

--- a/windowsservercore-insider/Dockerfile
+++ b/windowsservercore-insider/Dockerfile
@@ -25,4 +25,4 @@ RUN c:\windows\system32\inetsrv\appcmd.exe set config -section:system.applicatio
 
 EXPOSE 80
 
-ENTRYPOINT C:\LogMonitor\LogMonitor.exe C:\\ServiceMonitor.exe w3svc
+ENTRYPOINT C:\LogMonitor\LogMonitor.exe C:\ServiceMonitor.exe w3svc

--- a/windowsservercore-insider/LogMonitorConfig.json
+++ b/windowsservercore-insider/LogMonitorConfig.json
@@ -1,0 +1,17 @@
+{
+  "LogConfig": {
+    "sources": [
+      {
+        "type": "ETW",
+        "eventFormatMultiLine": false,
+        "providers": [
+          {
+            "providerName": "Microsoft-Windows-IIS-Logging",
+            "providerGuid": "7E8AD27F-B271-4EA2-A783-A47BDE29143B",
+            "level": "Information"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
1. Dockerfile is updated to install the logmonitor and enable ETW logging for the default web site
2. Added the logmonitor configuration file
NOTE: The version of servicemonitor.exe and logmonitor.exe will be updated when the new version is released.

Other related PR's:
https://github.com/microsoft/mcr/pull/833
https://github.com/microsoft/mcrdocs/pull/354