### PR TITLE
Remove support for 20H2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,6 @@
 
  [`windowsservercore-ltsc2022, latest` (*windowsserver/Dockerfile*)](https://github.com/Microsoft/iis-docker/blob/main/windowsservercore-ltsc2022/Dockerfile)
 
-# Supported Windows Server, version 20H2 amd64 tags
-
- `docker pull mcr.microsoft.com/windows/servercore/iis:windowsservercore-20H2`
-
- [`windowsservercore-20H2, latest` (*windowsserver/Dockerfile*)](https://github.com/Microsoft/iis-docker/blob/main/windowsservercore-20H2/Dockerfile)
-
 # Supported Windows Server 2019 amd64 tags
 
  `docker pull mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019`


### PR DESCRIPTION
Removing 20H2 due to the end of its support in August 2022. More information: [Windows Server Release Information](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fwindows-server%2Fget-started%2Fwindows-server-release-info%23windows-server-current-versions-by-servicing-option&data=05%7C01%7Cdrielene%40microsoft.com%7C233534e650c14ed73d8e08da904afe40%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C637980949014817994%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=C6915sQmY2XukOrrPTi52S9fAMatbNKlpvQB2r6uTG8%3D&reserved=0)